### PR TITLE
Beta2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 ![demo](./demo.png)
 
-一个基于 Cloudflare Workers 的代理可用性检测工具。项目以单个 `_worker.js` 运行为核心，支持 SOCKS5、HTTP、HTTPS、TURN 代理检测，提供网页端单条/批量检测、域名解析、出口 IP 信息展示、地图定位、结果筛选与导出。
+一个基于 Cloudflare Workers 的代理可用性检测工具。项目以单个 `_worker.js` 运行为核心，支持 SOCKS5、HTTP、HTTPS、TURN、SSTP 代理检测，提供网页端单条/批量检测、域名解析、出口 IP 信息展示、地图定位、结果筛选与导出。
 
 > 当前源码没有内置 `TOKEN` 鉴权。部署到公开域名后，任何访问者都可以使用检测接口；如果需要私有使用，请在 Cloudflare 侧增加访问控制或自行扩展鉴权逻辑。
 
 ## 功能特性
 
-- 支持 `socks5://`、`http://`、`https://`、`turn://` 四类代理协议。
+- 支持 `socks5://`、`http://`、`https://`、`turn://`、`sstp://` 五类代理协议。
 - 支持无认证代理、`username:password` 认证代理，以及 IPv4、域名、方括号 IPv6 地址。
 - TURN 检测使用 TCP Allocation / CONNECT / ConnectionBind 流程，支持无认证 TURN 服务器和长期凭据认证。
+- SSTP 检测使用 HTTPS SSTP 握手、PPP / IPCP 建链，并通过 PPP 内 TCP 连接读取出口信息。
 - 支持单条检测和批量检测；批量模式会自动去重、解析域名并并发验证。
 - 支持域名解析为 A / AAAA 记录，优先使用 Cloudflare DoH，失败后回退到 Google DoH。
 - 支持代理出口信息展示，包括出口 IP、地区、ASN、运营商、风险标签、响应耗时等。
@@ -50,13 +51,15 @@ Demo: <https://check.socks5.cmliussss.net>
 ```text
 socks5://host:1080
 socks5://username:password@host:1080
+socks5://username:password@[2001:db8::1]:1080
 http://host:80
 http://username:password@host:80
 https://host:443
 https://username:password@host:443
 turn://host:3478
 turn://username:password@host:3478
-socks5://username:password@[2001:db8::1]:1080
+sstp://host:443
+sstp://username:password@host:443
 ```
 
 网页端输入缺少协议头时，会默认按 `socks5://` 处理。端口缺省值分别为：
@@ -67,6 +70,7 @@ socks5://username:password@[2001:db8::1]:1080
 | `http` | `80` |
 | `https` | `443` |
 | `turn` | `3478` |
+| `sstp` | `443` |
 
 ### TURN 支持说明
 
@@ -79,6 +83,16 @@ socks5://username:password@[2001:db8::1]:1080
 - 目标出口检测地址会解析为 IPv4 后发起 TURN CONNECT；当前不走 TURN UDP relay，也不支持 `turns://`。
 - `turn://` 中的主机可以是 IP 或域名，端口未填写时默认使用 `3478`。
 
+### SSTP 支持说明
+
+`sstp://` 目标会被当作 SSTP over TLS 服务器检测。Worker 会先建立 SSTP HTTP 隧道，再完成 PPP / IPCP 协商，随后在 PPP 内构造 TCP 连接访问 `api.ipapi.is:443`，最后读取出口 IP 信息。
+
+当前 SSTP 实现有以下边界：
+
+- 支持无认证 SSTP 服务器；如果 PPP 协商要求认证，仅支持 PAP，并使用链接中提供的 `username:password`。
+- 目标出口检测地址会解析为 IPv4 后建立 PPP 内 TCP 连接；当前 SSTP 检测依赖服务端分配 IPv4 地址。
+- `sstp://` 中的主机可以是 IP 或域名，端口未填写时默认使用 `443`。
+
 ## API
 
 所有 JSON 接口都带有 CORS 响应头，并支持 `OPTIONS` 预检请求。
@@ -90,12 +104,17 @@ socks5://username:password@[2001:db8::1]:1080
 请求参数支持以下写法：
 
 ```text
-/check?proxy=socks5://user:pass@proxy.example.com:1080
 /check?socks5=proxy.example.com:1080
 /check?http=proxy.example.com:80
 /check?https=proxy.example.com:443
 /check?turn=turn.example.com:3478
+/check?sstp=vpn:vpn@vpn205396913.opengw.net:1922
+
+/check?proxy=socks5://user:pass@proxy.example.com:1080
+/check?proxy=http://proxy.example.com:80
+/check?proxy=https://proxy.example.com:443
 /check?proxy=turn://user:pass@turn.example.com:3478
+/check?proxy=sstp://vpn:vpn@vpn890321947.opengw.net:1630
 /check/proxy=socks5://proxy.example.com:1080
 ```
 
@@ -228,6 +247,7 @@ https://your-worker.example.workers.dev/socks5://proxy.example.com:1080
 - Cloudflare Workers 的 TCP Socket 能力由 `cloudflare:sockets` 提供，请确保部署环境支持 Workers TCP 出站连接。
 - 检测逻辑会把代理作为隧道访问 `api.ipapi.is`，因此结果反映的是该代理访问该目标服务时的可用性和出口信息。
 - TURN 检测依赖 TURN 服务器支持 TCP relay / CONNECT；只支持 UDP relay 的 TURN 服务会检测失败。
+- SSTP 检测依赖服务端支持 SSTP over TLS、PPP / IPCP 和 IPv4 分配；仅支持 PAP 认证，不支持 MS-CHAP 等其他 PPP 认证方式。
 - 公开部署时请谨慎使用真实代理账号密码；当前页面和接口没有访问令牌保护。
 - 大批量检测可能受到 Cloudflare Workers 执行时长、并发和外部 DNS/API 可用性的影响。
 

--- a/_worker.js
+++ b/_worker.js
@@ -5,12 +5,13 @@ const CONNECT_TIMEOUT_MS = 9999;
 const READ_TIMEOUT_MS = 8000;
 const MAX_RESPONSE_BYTES = 96 * 1024;
 const RESOLVE_BATCH_LIMIT = 50;
-const PROXY_TYPES = ['socks5', 'http', 'https', 'turn'];
+const PROXY_TYPES = ['socks5', 'http', 'https', 'turn', 'sstp'];
 const DEFAULT_PORTS = {
 	socks5: 1080,
 	http: 80,
 	https: 443,
-	turn: 3478
+	turn: 3478,
+	sstp: 443
 };
 
 const encoder = new TextEncoder();
@@ -150,7 +151,7 @@ export default {
 
 				if (!checkParams) {
 					const tail = decodeURIComponent(url.pathname.slice('/check'.length).replace(/^\/+/, ''));
-					const pathMatch = tail.match(/^(socks5|http|https|turn|proxy)=(.+)$/i);
+					const pathMatch = tail.match(/^(socks5|http|https|turn|sstp|proxy)=(.+)$/i);
 					if (pathMatch) {
 						const key = pathMatch[1].toLowerCase();
 						const value = pathMatch[2];
@@ -165,7 +166,7 @@ export default {
 				if (!checkParams) {
 					return jsonResponse({
 						success: false,
-						error: 'Missing proxy parameter. Use /check?socks5=host:port, /check?http=host:port, /check?https=host:port, /check?turn=host:port or /check?proxy=socks5://host:port'
+						error: 'Missing proxy parameter. Use /check?socks5=host:port, /check?http=host:port, /check?https=host:port, /check?turn=host:port, /check?sstp=host:port or /check?proxy=socks5://host:port'
 					}, { status: 400, origin });
 				}
 				const result = await checkProxy(checkParams);
@@ -243,6 +244,8 @@ async function checkProxy({ type, value }) {
 				: httpConnect(proxy, targetHost, targetPort, true);
 		} else if (proxy.type === 'turn') {
 			tunnelPromise = turnConnect(proxy, targetHost, targetPort);
+		} else if (proxy.type === 'sstp') {
+			tunnelPromise = sstpConnect(proxy, targetHost, targetPort);
 		} else {
 			throw new Error(`Unsupported proxy type: ${proxy.type}`);
 		}
@@ -925,6 +928,593 @@ async function httpsConnect(proxy, targetHost, targetPort) {
 	}
 }
 
+const SSTP_TCP_MSS = 1400;
+const SSTP_EMPTY_BYTES = new Uint8Array(0);
+
+function readSstpUint16(bytes, offset = 0) {
+	return (bytes[offset] << 8) | bytes[offset + 1];
+}
+
+function readSstpUint32(bytes, offset = 0) {
+	return ((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0;
+}
+
+function randomSstpBytes(length) {
+	return crypto.getRandomValues(new Uint8Array(length));
+}
+
+function randomSstpUint16() {
+	return readSstpUint16(randomSstpBytes(2));
+}
+
+function randomSstpUint32() {
+	return readSstpUint32(randomSstpBytes(4));
+}
+
+function ipv4ToBytes(ip) {
+	return new Uint8Array(String(ip || '').split('.').map(Number));
+}
+
+function internetChecksum(bytes, offset, length) {
+	let sum = 0;
+	for (let index = offset; index < offset + length - 1; index += 2) {
+		sum += readSstpUint16(bytes, index);
+	}
+	if (length & 1) sum += bytes[offset + length - 1] << 8;
+	while (sum >> 16) sum = (sum & 0xffff) + (sum >> 16);
+	return (~sum) & 0xffff;
+}
+
+function formatSstpHostHeader(hostname, port) {
+	const host = stripIPv6Brackets(hostname);
+	const displayHost = host.includes(':') ? `[${host}]` : host;
+	return Number(port) === 443 ? displayHost : `${displayHost}:${port}`;
+}
+
+async function resolveSstpTargetIPv4(targetHost) {
+	const host = stripIPv6Brackets(targetHost);
+	if (isIPv4(host)) return host;
+
+	const records = await DoH查询(host, 'A');
+	const record = records.find(item => item.type === 1 && isIPv4(item.data));
+	if (!record?.data) throw new Error(`Could not resolve ${targetHost} to an IPv4 address for SSTP`);
+	return record.data;
+}
+
+function createSstpClient(proxy) {
+	let bufferedBytes = SSTP_EMPTY_BYTES;
+	let pppIdentifier = 1;
+	let socket = null;
+	let reader = null;
+	let writer = null;
+	let serverHost = '';
+	let serverPort = 443;
+
+	const readSocketChunk = async () => {
+		const { value, done } = await reader.read();
+		if (done || !value) throw new Error('SSTP socket closed');
+		return 数据转Uint8Array(value);
+	};
+
+	const readBytes = async length => {
+		while (bufferedBytes.byteLength < length) {
+			const chunk = await readSocketChunk();
+			bufferedBytes = bufferedBytes.byteLength ? concatUint8(bufferedBytes, chunk) : chunk;
+		}
+		const result = bufferedBytes.subarray(0, length);
+		bufferedBytes = bufferedBytes.subarray(length);
+		return result;
+	};
+
+	const readHttpLine = async () => {
+		for (;;) {
+			const lineEnd = bufferedBytes.indexOf(10);
+			if (lineEnd >= 0) {
+				const line = decoder.decode(bufferedBytes.subarray(0, lineEnd));
+				bufferedBytes = bufferedBytes.subarray(lineEnd + 1);
+				return line.replace(/\r$/, '');
+			}
+
+			const chunk = await readSocketChunk();
+			bufferedBytes = bufferedBytes.byteLength ? concatUint8(bufferedBytes, chunk) : chunk;
+		}
+	};
+
+	const readPacket = async (timeoutMs = CONNECT_TIMEOUT_MS) => {
+		const header = await withTimeout(readBytes(4), timeoutMs, 'SSTP read timeout');
+		const length = readSstpUint16(header, 2) & 0x0fff;
+		if (length < 4) throw new Error('Invalid SSTP packet length');
+		return {
+			isControl: (header[1] & 1) !== 0,
+			body: length > 4 ? await withTimeout(readBytes(length - 4), timeoutMs, 'SSTP packet body read timeout') : SSTP_EMPTY_BYTES
+		};
+	};
+
+	const buildSstpDataPacket = pppFrame => {
+		const packetLength = 6 + pppFrame.byteLength;
+		const packet = new Uint8Array(packetLength);
+		packet.set([0x10, 0x00, ((packetLength >> 8) & 0x0f) | 0x80, packetLength & 0xff, 0xff, 0x03]);
+		packet.set(pppFrame, 6);
+		return packet;
+	};
+
+	const buildSstpControlPacket = (messageType, attributes = []) => {
+		const attributesLength = attributes.reduce((size, attribute) => size + 4 + attribute.data.byteLength, 0);
+		const packet = new Uint8Array(8 + attributesLength);
+		const view = new DataView(packet.buffer);
+		packet[0] = 0x10;
+		packet[1] = 0x01;
+		view.setUint16(2, (8 + attributesLength) | 0x8000);
+		view.setUint16(4, messageType);
+		view.setUint16(6, attributes.length);
+
+		attributes.reduce((offset, attribute) => {
+			packet[offset + 1] = attribute.id;
+			view.setUint16(offset + 2, 4 + attribute.data.byteLength);
+			packet.set(attribute.data, offset + 4);
+			return offset + 4 + attribute.data.byteLength;
+		}, 8);
+		return packet;
+	};
+
+	const buildPppConfigurePacket = (protocol, code, id, options = []) => {
+		const optionsLength = options.reduce((size, option) => size + 2 + option.data.byteLength, 0);
+		const frame = new Uint8Array(6 + optionsLength);
+		const view = new DataView(frame.buffer);
+		view.setUint16(0, protocol);
+		frame[2] = code;
+		frame[3] = id;
+		view.setUint16(4, 4 + optionsLength);
+
+		options.reduce((offset, option) => {
+			frame[offset] = option.type;
+			frame[offset + 1] = 2 + option.data.byteLength;
+			frame.set(option.data, offset + 2);
+			return offset + 2 + option.data.byteLength;
+		}, 6);
+		return frame;
+	};
+
+	const buildPapAuthenticateRequest = id => {
+		if (proxy.username === null || proxy.password === null) throw new Error('SSTP server requires PAP authentication');
+		const username = encoder.encode(proxy.username);
+		const password = encoder.encode(proxy.password);
+		if (username.byteLength > 255 || password.byteLength > 255) throw new Error('SSTP username/password is too long');
+
+		const papLength = 6 + username.byteLength + password.byteLength;
+		const frame = new Uint8Array(2 + papLength);
+		const view = new DataView(frame.buffer);
+		view.setUint16(0, 0xc023);
+		frame[2] = 1;
+		frame[3] = id;
+		view.setUint16(4, papLength);
+		frame[6] = username.byteLength;
+		frame.set(username, 7);
+		frame[7 + username.byteLength] = password.byteLength;
+		frame.set(password, 8 + username.byteLength);
+		return frame;
+	};
+
+	const parsePPPFrame = data => {
+		const offset = data.byteLength >= 2 && data[0] === 0xff && data[1] === 0x03 ? 2 : 0;
+		if (data.byteLength - offset < 4) return null;
+
+		const protocol = readSstpUint16(data, offset);
+		if (protocol === 0x0021) {
+			return {
+				protocol,
+				ipPacket: data.subarray(offset + 2)
+			};
+		}
+		if (data.byteLength - offset < 6) return null;
+		return {
+			protocol,
+			code: data[offset + 2],
+			id: data[offset + 3],
+			payload: data.subarray(offset + 6),
+			rawPacket: data.subarray(offset)
+		};
+	};
+
+	const parsePppOptions = data => {
+		const options = [];
+		for (let offset = 0; offset + 2 <= data.byteLength;) {
+			const type = data[offset];
+			const length = data[offset + 1];
+			if (length < 2 || offset + length > data.byteLength) break;
+			options.push({
+				type,
+				data: data.subarray(offset + 2, offset + length)
+			});
+			offset += length;
+		}
+		return options;
+	};
+
+	const connectToServer = async (hostname, port) => {
+		serverHost = stripIPv6Brackets(hostname);
+		serverPort = port;
+		socket = connect({ hostname: serverHost, port: serverPort }, { secureTransport: 'on', allowHalfOpen: false });
+		await withTimeout(socket.opened, CONNECT_TIMEOUT_MS, 'SSTP server connection timed out');
+		reader = socket.readable.getReader();
+		writer = socket.writable.getWriter();
+	};
+
+	const establishTunnel = async () => {
+		const httpRequest = encoder.encode(
+			`SSTP_DUPLEX_POST /sra_{BA195980-CD49-458b-9E23-C84EE0ADCD75}/ HTTP/1.1\r\n`
+			+ `Host: ${formatSstpHostHeader(serverHost, serverPort)}\r\n`
+			+ 'Content-Length: 18446744073709551615\r\n'
+			+ `SSTPCORRELATIONID: {${crypto.randomUUID()}}\r\n\r\n`
+		);
+		const encapsulatedProtocol = new Uint8Array(2);
+		new DataView(encapsulatedProtocol.buffer).setUint16(0, 1);
+		const maximumReceiveUnit = new Uint8Array(2);
+		new DataView(maximumReceiveUnit.buffer).setUint16(0, 1500);
+
+		await withTimeout(writer.write(concatUint8(
+			httpRequest,
+			buildSstpControlPacket(0x0001, [{ id: 1, data: encapsulatedProtocol }]),
+			buildSstpDataPacket(buildPppConfigurePacket(0xc021, 1, pppIdentifier++, [
+				{ type: 1, data: maximumReceiveUnit }
+			]))
+		)), CONNECT_TIMEOUT_MS, 'SSTP HTTP handshake request timed out');
+
+		const statusLine = await withTimeout(readHttpLine(), CONNECT_TIMEOUT_MS, 'SSTP HTTP handshake timed out');
+		for (;;) {
+			const line = await withTimeout(readHttpLine(), CONNECT_TIMEOUT_MS, 'SSTP HTTP header read timed out');
+			if (line === '') break;
+		}
+		if (!/HTTP\/\d(?:\.\d)?\s+2\d\d/i.test(statusLine)) throw new Error(`SSTP HTTP handshake failed: ${statusLine || 'invalid status'}`);
+
+		let sstpAccepted = false;
+		let localLcpAcked = false;
+		let peerLcpAcked = false;
+		let papRequired = false;
+		let papSent = false;
+		let papDone = false;
+		let ipcpStarted = false;
+		let ipcpFinished = false;
+		let assignedIp = null;
+
+		const sendPapIfReady = async () => {
+			if (!localLcpAcked || !peerLcpAcked || !papRequired || papSent) return;
+			await withTimeout(writer.write(buildSstpDataPacket(buildPapAuthenticateRequest(pppIdentifier++))), CONNECT_TIMEOUT_MS, 'SSTP PAP authentication request timed out');
+			papSent = true;
+		};
+
+		const startIpcpIfReady = async () => {
+			if (!localLcpAcked || !peerLcpAcked || ipcpStarted || (papRequired && !papDone)) return;
+			await withTimeout(writer.write(buildSstpDataPacket(buildPppConfigurePacket(0x8021, 1, pppIdentifier++, [
+				{ type: 3, data: new Uint8Array(4) }
+			]))), CONNECT_TIMEOUT_MS, 'SSTP IPCP request timed out');
+			ipcpStarted = true;
+		};
+
+		for (let round = 0; round < 50 && !ipcpFinished; round++) {
+			const packet = await readPacket(CONNECT_TIMEOUT_MS);
+
+			if (packet.isControl) {
+				if (!sstpAccepted && packet.body.byteLength >= 2 && readSstpUint16(packet.body) === 2) sstpAccepted = true;
+				continue;
+			}
+
+			const ppp = parsePPPFrame(packet.body);
+			if (!ppp) continue;
+
+			if (ppp.protocol === 0xc021) {
+				if (ppp.code === 1) {
+					const authOption = parsePppOptions(ppp.payload).find(option => option.type === 3);
+					if (authOption?.data?.byteLength >= 2) {
+						const authProtocol = readSstpUint16(authOption.data);
+						if (authProtocol !== 0xc023) throw new Error(`SSTP unsupported PPP authentication protocol: 0x${authProtocol.toString(16)}`);
+						papRequired = true;
+					}
+
+					const ack = new Uint8Array(ppp.rawPacket);
+					ack[2] = 2;
+					await withTimeout(writer.write(buildSstpDataPacket(ack)), CONNECT_TIMEOUT_MS, 'SSTP LCP Configure-Ack timed out');
+					peerLcpAcked = true;
+					await sendPapIfReady();
+					await startIpcpIfReady();
+				} else if (ppp.code === 2) {
+					localLcpAcked = true;
+					await sendPapIfReady();
+					await startIpcpIfReady();
+				}
+				continue;
+			}
+
+			if (ppp.protocol === 0xc023) {
+				if (ppp.code === 2) {
+					papDone = true;
+					await startIpcpIfReady();
+				} else if (ppp.code === 3) {
+					throw new Error('SSTP PAP authentication failed');
+				}
+				continue;
+			}
+
+			if (ppp.protocol === 0x8021) {
+				if (ppp.code === 1) {
+					const ack = new Uint8Array(ppp.rawPacket);
+					ack[2] = 2;
+					await withTimeout(writer.write(buildSstpDataPacket(ack)), CONNECT_TIMEOUT_MS, 'SSTP IPCP Configure-Ack timed out');
+					await startIpcpIfReady();
+				} else if (ppp.code === 3) {
+					const addressOption = parsePppOptions(ppp.payload).find(option => option.type === 3);
+					if (addressOption?.data?.byteLength === 4) {
+						assignedIp = [...addressOption.data].join('.');
+						await withTimeout(writer.write(buildSstpDataPacket(buildPppConfigurePacket(0x8021, 1, pppIdentifier++, [
+							{ type: 3, data: addressOption.data }
+						]))), CONNECT_TIMEOUT_MS, 'SSTP IPCP address request timed out');
+						ipcpStarted = true;
+					}
+				} else if (ppp.code === 2) {
+					const addressOption = parsePppOptions(ppp.payload).find(option => option.type === 3);
+					if (addressOption?.data?.byteLength === 4) assignedIp = [...addressOption.data].join('.');
+					ipcpFinished = true;
+				}
+			}
+		}
+
+		if (!assignedIp) throw new Error('SSTP did not assign an IPv4 address');
+		return assignedIp;
+	};
+
+	const close = () => {
+		try { reader?.cancel?.().catch?.(() => { }); } catch (e) { }
+		try { reader?.releaseLock?.(); } catch (e) { }
+		try { writer?.close?.().catch?.(() => { }); } catch (e) { }
+		try { writer?.releaseLock?.(); } catch (e) { }
+		try { socket?.close?.(); } catch (e) { }
+	};
+
+	return {
+		connect: connectToServer,
+		establishTunnel,
+		readPacket,
+		parsePPPFrame,
+		close,
+		get bufferedBytes() {
+			return bufferedBytes;
+		},
+		get writer() {
+			return writer;
+		}
+	};
+}
+
+function createTcpOverPppSession(sstp, sourceIp, destinationIp, destinationPort) {
+	const sourcePort = 10000 + (randomSstpUint16() % 50000);
+	const sourceAddress = ipv4ToBytes(sourceIp);
+	const destinationAddress = ipv4ToBytes(destinationIp);
+
+	let sequenceNumber = randomSstpUint32();
+	let acknowledgementNumber = 0;
+
+	const ipHeaderTemplate = new Uint8Array(20);
+	ipHeaderTemplate.set([0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 64, 6]);
+	ipHeaderTemplate.set(sourceAddress, 12);
+	ipHeaderTemplate.set(destinationAddress, 16);
+
+	const tcpPseudoHeader = new Uint8Array(1432);
+	tcpPseudoHeader.set(sourceAddress);
+	tcpPseudoHeader.set(destinationAddress, 4);
+	tcpPseudoHeader[9] = 6;
+
+	const buildTcpFrame = (flags, payload = SSTP_EMPTY_BYTES) => {
+		const bytes = 数据转Uint8Array(payload);
+		const payloadLength = bytes.byteLength;
+		const tcpLength = 20 + payloadLength;
+		const ipLength = 20 + tcpLength;
+		const sstpLength = 8 + ipLength;
+		const frame = new Uint8Array(sstpLength);
+		const view = new DataView(frame.buffer);
+
+		frame.set([0x10, 0x00, ((sstpLength >> 8) & 0x0f) | 0x80, sstpLength & 0xff, 0xff, 0x03, 0x00, 0x21]);
+		frame.set(ipHeaderTemplate, 8);
+		view.setUint16(10, ipLength);
+		view.setUint16(12, randomSstpUint16());
+		view.setUint16(18, internetChecksum(frame, 8, 20));
+
+		view.setUint16(28, sourcePort);
+		view.setUint16(30, destinationPort);
+		view.setUint32(32, sequenceNumber);
+		view.setUint32(36, acknowledgementNumber);
+		frame[40] = 0x50;
+		frame[41] = flags;
+		view.setUint16(42, 65535);
+		if (payloadLength) frame.set(bytes, 48);
+
+		tcpPseudoHeader[10] = tcpLength >> 8;
+		tcpPseudoHeader[11] = tcpLength & 0xff;
+		tcpPseudoHeader.set(frame.subarray(28, 28 + tcpLength), 12);
+		view.setUint16(44, internetChecksum(tcpPseudoHeader, 0, 12 + tcpLength));
+		return frame;
+	};
+
+	const matchIncomingIpPacket = ipPacket => {
+		if (ipPacket.byteLength < 40 || ipPacket[9] !== 6) return null;
+		const ipHeaderLength = (ipPacket[0] & 0x0f) * 4;
+		if (ipPacket.byteLength < ipHeaderLength + 20) return null;
+		if (readSstpUint16(ipPacket, ipHeaderLength) !== destinationPort) return null;
+		if (readSstpUint16(ipPacket, ipHeaderLength + 2) !== sourcePort) return null;
+		return {
+			flags: ipPacket[ipHeaderLength + 13],
+			sequence: readSstpUint32(ipPacket, ipHeaderLength + 4),
+			payloadOffset: ipHeaderLength + ((ipPacket[ipHeaderLength + 12] >> 4) & 0x0f) * 4
+		};
+	};
+
+	const handshake = async () => {
+		await withTimeout(sstp.writer.write(buildTcpFrame(0x02)), CONNECT_TIMEOUT_MS, 'SSTP TCP SYN write timed out');
+		sequenceNumber = (sequenceNumber + 1) >>> 0;
+
+		for (let attempt = 0; attempt < 30; attempt++) {
+			const packet = await sstp.readPacket(CONNECT_TIMEOUT_MS);
+			if (packet.isControl) continue;
+
+			const ppp = sstp.parsePPPFrame(packet.body);
+			if (!ppp || ppp.protocol !== 0x0021) continue;
+
+			const tcp = matchIncomingIpPacket(ppp.ipPacket);
+			if (!tcp || (tcp.flags & 0x12) !== 0x12) continue;
+
+			acknowledgementNumber = (tcp.sequence + 1) >>> 0;
+			await withTimeout(sstp.writer.write(buildTcpFrame(0x10)), CONNECT_TIMEOUT_MS, 'SSTP TCP ACK write timed out');
+			return;
+		}
+		throw new Error('TCP handshake through SSTP timed out');
+	};
+
+	return {
+		buildTcpFrame,
+		matchIncomingIpPacket,
+		handshake,
+		get sequenceNumber() {
+			return sequenceNumber;
+		},
+		set sequenceNumber(value) {
+			sequenceNumber = value >>> 0;
+		},
+		get acknowledgementNumber() {
+			return acknowledgementNumber;
+		},
+		set acknowledgementNumber(value) {
+			acknowledgementNumber = value >>> 0;
+		}
+	};
+}
+
+async function sstpConnect(proxy, targetHost, targetPort) {
+	const sstp = createSstpClient(proxy);
+	let closedSettled = false;
+	let resolveClosed;
+	let rejectClosed;
+	const closed = new Promise((resolve, reject) => {
+		resolveClosed = resolve;
+		rejectClosed = reject;
+	});
+	const settleClosed = (settle, value) => {
+		if (closedSettled) return;
+		closedSettled = true;
+		settle(value);
+	};
+	const close = () => {
+		try { sstp.close(); } catch (e) { }
+		settleClosed(resolveClosed);
+	};
+
+	try {
+		await sstp.connect(proxy.hostname, proxy.port);
+		const targetIpPromise = resolveSstpTargetIPv4(targetHost);
+		const [sourceIp, targetIp] = await Promise.all([
+			sstp.establishTunnel(),
+			targetIpPromise
+		]);
+
+		const tcp = createTcpOverPppSession(sstp, sourceIp, targetIp, targetPort);
+		await tcp.handshake();
+
+		/** @type {ReadableStreamDefaultController<Uint8Array> | null} */
+		let streamController = null;
+		const readable = new ReadableStream({
+			start(controller) {
+				streamController = controller;
+			},
+			cancel() {
+				close();
+			}
+		});
+
+		(async () => {
+			try {
+				let pendingChunks = [];
+				let pendingLength = 0;
+
+				const flush = () => {
+					if (!pendingLength) return;
+					const controller = streamController;
+					if (!controller) throw new Error('SSTP readable stream is not ready');
+					controller.enqueue(pendingChunks.length === 1 ? pendingChunks[0] : concatUint8(...pendingChunks));
+					pendingChunks = [];
+					pendingLength = 0;
+					sstp.writer.write(tcp.buildTcpFrame(0x10)).catch(() => { });
+				};
+
+				for (;;) {
+					const packet = await sstp.readPacket(60000);
+					if (packet.isControl) continue;
+
+					const ppp = sstp.parsePPPFrame(packet.body);
+					if (!ppp || ppp.protocol !== 0x0021) continue;
+
+					const incoming = tcp.matchIncomingIpPacket(ppp.ipPacket);
+					if (!incoming) continue;
+
+					if (incoming.payloadOffset < ppp.ipPacket.byteLength) {
+						const payload = ppp.ipPacket.subarray(incoming.payloadOffset);
+						if (payload.byteLength) {
+							tcp.acknowledgementNumber = (incoming.sequence + payload.byteLength) >>> 0;
+							pendingChunks.push(new Uint8Array(payload));
+							pendingLength += payload.byteLength;
+						}
+					}
+
+					if (incoming.flags & 0x01) {
+						flush();
+						tcp.acknowledgementNumber = (tcp.acknowledgementNumber + 1) >>> 0;
+						sstp.writer.write(tcp.buildTcpFrame(0x11)).catch(() => { });
+						try { streamController?.close?.(); } catch (e) { }
+						close();
+						return;
+					}
+
+					if (sstp.bufferedBytes.byteLength < 4 || pendingLength >= 32768) flush();
+				}
+			} catch (error) {
+				try { streamController?.error?.(error); } catch (e) { }
+				settleClosed(rejectClosed, error);
+				try { sstp.close(); } catch (e) { }
+			}
+		})();
+
+		const writable = new WritableStream({
+			async write(chunk) {
+				const bytes = 数据转Uint8Array(chunk);
+				if (!bytes.byteLength) return;
+
+				if (bytes.byteLength <= SSTP_TCP_MSS) {
+					await sstp.writer.write(tcp.buildTcpFrame(0x18, bytes));
+					tcp.sequenceNumber = (tcp.sequenceNumber + bytes.byteLength) >>> 0;
+					return;
+				}
+
+				const frames = [];
+				for (let offset = 0; offset < bytes.byteLength; offset += SSTP_TCP_MSS) {
+					const segment = bytes.subarray(offset, Math.min(offset + SSTP_TCP_MSS, bytes.byteLength));
+					frames.push(tcp.buildTcpFrame(0x18, segment));
+					tcp.sequenceNumber = (tcp.sequenceNumber + segment.byteLength) >>> 0;
+				}
+				await sstp.writer.write(concatUint8(...frames));
+			},
+			close() {
+				return sstp.writer.write(tcp.buildTcpFrame(0x11)).catch(() => { });
+			},
+			abort(error) {
+				close();
+				if (error) settleClosed(rejectClosed, error);
+			}
+		});
+
+		return { readable, writable, closed, close };
+	} catch (error) {
+		close();
+		throw error;
+	}
+}
+
 function parseProxyAddress(input, type, defaultPort = 80) {
 	let address = stripProxyScheme(String(input || '').trim()).split('#')[0].trim();
 	if (!address) throw new Error('Proxy address cannot be empty');
@@ -982,12 +1572,12 @@ const BASE64_AUTH_RE = /^(?:[A-Z0-9+/]{4})*(?:[A-Z0-9+/]{2}==|[A-Z0-9+/]{3}=)?$/
 
 function splitProxyScheme(input) {
 	const text = String(input || '').trim();
-	const match = text.match(/^(socks5|http|https|turn):\/\/(.+)$/i);
+	const match = text.match(/^(socks5|http|https|turn|sstp):\/\/(.+)$/i);
 	return match ? { type: match[1].toLowerCase(), rest: match[2] } : null;
 }
 
 function stripProxyScheme(input) {
-	return String(input || '').replace(/^(socks5|http|https|turn):\/\//i, '');
+	return String(input || '').replace(/^(socks5|http|https|turn|sstp):\/\//i, '');
 }
 
 function formatProxyAuthority(proxy) {
@@ -1068,6 +1658,10 @@ function isIPv4(value) {
 async function handleResolve(input) {
 	let text = String(input || '').trim().split('#')[0].trim();
 	const proxy = splitProxyScheme(text);
+	if (proxy?.type === 'sstp') {
+		const parsed = parseProxyAddress(text, proxy.type, DEFAULT_PORTS[proxy.type]);
+		return [`${parsed.hostname}:${parsed.port}`];
+	}
 	if (proxy) text = proxy.rest;
 	if (text.includes('@')) text = text.slice(text.lastIndexOf('@') + 1);
 
@@ -3479,7 +4073,7 @@ function generateHTML(备案内容) {
 					</button>
 				</div>
 			</div>
-			<div class="header-note">基于 Cloudflare Workers 的 SOCKS5 / HTTP / HTTPS / TURN 代理检测工具，支持单个或批量代理解析、可用性验证与出口信息查看。</div>
+			<div class="header-note">基于 Cloudflare Workers 的 SOCKS5 / HTTP / HTTPS / TURN / SSTP 代理检测工具，支持单个或批量代理解析、可用性验证与出口信息查看。</div>
 		</header>
 
 		<main class="site-main">
@@ -3489,7 +4083,7 @@ function generateHTML(备案内容) {
 						<div>
 							<p class="section-kicker">Workspace</p>
 							<h2 class="panel-title">开始检测</h2>
-							<p class="panel-copy">输入单个代理链接、IP:端口、域名:端口或一整段列表，支持 SOCKS5 / HTTP / HTTPS / TURN。缺少协议头时会自动按 socks5:// 处理。</p>
+							<p class="panel-copy">输入单个代理链接、IP:端口、域名:端口或一整段列表，支持 SOCKS5 / HTTP / HTTPS / TURN / SSTP。缺少协议头时会自动按 socks5:// 处理。</p>
 						</div>
 						<div class="panel-badge">实时解析与验证</div>
 					</div>
@@ -3708,7 +4302,8 @@ function generateHTML(备案内容) {
 			{ key: 'socks5', label: 'SOCKS5' },
 			{ key: 'http', label: 'HTTP' },
 			{ key: 'https', label: 'HTTPS' },
-			{ key: 'turn', label: 'TURN' }
+			{ key: 'turn', label: 'TURN' },
+			{ key: 'sstp', label: 'SSTP' }
 		];
 		const EXPORT_CSV_COLUMNS = [
 			{ header: 'TYPE', path: 'type' },
@@ -4198,7 +4793,7 @@ function generateHTML(备案内容) {
 		}
 
 		function collectUrlTargetMatches(line, matches) {
-			const pattern = /(?:https?|wss?|tcp|tls|socks5?|turn):\\/\\/[^\\s'"<>|]+/ig;
+			const pattern = /(?:https?|wss?|tcp|tls|socks5?|turn|sstp):\\/\\/[^\\s'"<>|]+/ig;
 			let match;
 			while ((match = pattern.exec(line)) !== null) {
 				addTargetMatch(line, matches, match.index, match.index + match[0].length, match[0]);
@@ -4258,7 +4853,7 @@ function generateHTML(备案内容) {
 			let token = trimTargetToken(stripInlineComment(value).replace(/\uFF1A/g, ':'));
 			if (!token) return '';
 			while (token.charAt(0) === '/') token = token.slice(1);
-			if (!/^(?:socks5|http|https|turn):\\/\\//i.test(token)) {
+			if (!/^(?:socks5|http|https|turn|sstp):\\/\\//i.test(token)) {
 				token = 'socks5://' + token;
 			}
 			try {
@@ -4270,13 +4865,13 @@ function generateHTML(备案内容) {
 		}
 
 		function getProxyDefaultPort(scheme) {
-			return scheme === 'turn' ? '3478' : (scheme === 'https' ? '443' : (scheme === 'http' ? '80' : '1080'));
+			return scheme === 'turn' ? '3478' : (scheme === 'sstp' || scheme === 'https' ? '443' : (scheme === 'http' ? '80' : '1080'));
 		}
 
 		function parseProxyUrl(value) {
 			const text = String(value || '').trim();
-			const match = text.match(/^(socks5|http|https|turn):\\/\\/(.+)$/i);
-			if (!match) throw new Error('只支持 socks5://、http://、https://、turn:// 代理');
+			const match = text.match(/^(socks5|http|https|turn|sstp):\\/\\/(.+)$/i);
+			if (!match) throw new Error('只支持 socks5://、http://、https://、turn://、sstp:// 代理');
 
 			const scheme = match[1].toLowerCase();
 			const defaultPort = getProxyDefaultPort(scheme);
@@ -4389,6 +4984,7 @@ function generateHTML(备案内容) {
 
 		function getDirectProxyTarget(input) {
 			const parsed = parseProxyUrl(input);
+			if (parsed.scheme === 'sstp') return parsed.normalized;
 			return isClientIpAddress(parsed.hostPlain) ? parsed.normalized : '';
 		}
 
@@ -4406,6 +5002,7 @@ function generateHTML(备案内容) {
 
 		function replaceProxyHost(proxyUrl, resolvedTarget) {
 			const parsed = parseProxyUrl(proxyUrl);
+			if (parsed.scheme === 'sstp') return parsed.normalized;
 			const target = parseResolvedTarget(resolvedTarget);
 			return normalizeParsedProxyParts(parsed.scheme, parsed.auth, target.host, target.port || parsed.port).normalized;
 		}
@@ -4777,7 +5374,7 @@ function generateHTML(备案内容) {
 
 		function normalizeProxyType(value) {
 			const type = String(value || '').trim().toLowerCase();
-			return type === 'socks5' || type === 'http' || type === 'https' || type === 'turn' ? type : '';
+			return type === 'socks5' || type === 'http' || type === 'https' || type === 'turn' || type === 'sstp' ? type : '';
 		}
 
 		function getProxyTypeFromTarget(target) {
@@ -5473,7 +6070,7 @@ function generateHTML(备案内容) {
 
 			if (isBatch) {
 				control = document.createElement('textarea');
-				control.placeholder = '每行一个代理，例如：\\nsocks5://user:pass@proxy.example.com:1080\\nhttp://1.1.1.1:8080\\nhttps://8.8.8.8:443\\nturn://test:test@167.172.34.1:3478';
+				control.placeholder = '每行一个代理，例如：\\nsocks5://user:pass@proxy.example.com:1080\\nhttp://1.1.1.1:8080\\nhttps://8.8.8.8:443\\nturn://test:test@167.172.34.1:3478\\nsstp://vpn:vpn@vpn986755484.opengw.net:1852';
 			} else {
 				control = document.createElement('input');
 				control.type = 'text';


### PR DESCRIPTION
This pull request updates the documentation to add support for SSTP proxy detection. The changes clarify that the tool now supports the `sstp://` protocol, describe its detection process and limitations, and provide usage examples for SSTP in both the feature list and API documentation.

**Feature and protocol support updates:**

* Added `SSTP` proxy detection to the list of supported protocols, including in the main feature description and protocol summary table. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73)
* Added detailed documentation of the SSTP detection process, including handshake, PPP/IPCP negotiation, and how exit IP information is retrieved. Described current limitations (e.g., only PAP authentication supported, requires IPv4 assignment). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86-R95) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R250)

**Usage examples and API documentation:**

* Updated example proxy URIs to include `sstp://` for both unauthenticated and authenticated usage.
* Expanded API request parameter examples to show how to use SSTP proxies with both dedicated and generic proxy parameters.