### PR TITLE
修复 TURN 身份验证挑战中缺失 realm 的错误处理逻辑

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -525,7 +525,7 @@ async function allocateTurnRelay(writer, reader, transport, credentials, pipelin
 	) {
 		const realmBytes = message.attributes[TURN_STUN_ATTR.REALM];
 		const nonce = message.attributes[TURN_STUN_ATTR.NONCE];
-		if (!realmBytes?.byteLength || !nonce?.byteLength) throw new Error('TURN authentication challenge is missing realm or nonce');
+		if (!realmBytes || !nonce?.byteLength) throw new Error('TURN authentication challenge is missing realm or nonce');
 
 		const realm = decoder.decode(realmBytes);
 		integrityKey = new Uint8Array(await crypto.subtle.digest('MD5', encoder.encode(`${credentials.username}:${realm}:${credentials.password}`)));


### PR DESCRIPTION
This pull request makes a minor update to the TURN authentication challenge handling logic. It slightly relaxes the check for the presence of the `realm` attribute in the TURN challenge message.

- TURN authentication: Adjusted the validation logic to allow empty `realm` values (as long as the attribute exists) instead of requiring a non-empty value, ensuring better compatibility with TURN servers that may send an empty realm. (`_worker.js`)