### PR TITLE
新增未知风险过滤器样式和逻辑，优化风险筛选功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /demo/
 .wrangler/
+.workbuddy/

--- a/_worker.js
+++ b/_worker.js
@@ -2881,6 +2881,17 @@ function generateHTML(备案内容) {
 			--risk-shadow: rgba(239, 68, 68, 0.2);
 		}
 
+		.filter-chip-risk.risk-unknown,
+		.meta-chip-risk.risk-unknown {
+			--risk-border: rgba(148, 163, 184, 0.32);
+			--risk-bg: rgba(148, 163, 184, 0.12);
+			--risk-color: #cbd5e1;
+			--risk-active-border: rgba(148, 163, 184, 0.6);
+			--risk-active-bg: linear-gradient(135deg, rgba(148, 163, 184, 0.34), rgba(100, 116, 139, 0.2));
+			--risk-active-color: #ffffff;
+			--risk-shadow: rgba(148, 163, 184, 0.18);
+		}
+
 		.export-chip {
 			border-color: rgba(251, 191, 36, 0.28);
 			background: linear-gradient(135deg, rgba(251, 191, 36, 0.18), rgba(255, 184, 105, 0.12));
@@ -3850,6 +3861,17 @@ function generateHTML(备案内容) {
 			--risk-shadow: rgba(220, 38, 38, 0.1);
 		}
 
+		html[data-theme='light'] .filter-chip-risk.risk-unknown,
+		html[data-theme='light'] .meta-chip-risk.risk-unknown {
+			--risk-border: rgba(100, 116, 139, 0.26);
+			--risk-bg: rgba(100, 116, 139, 0.08);
+			--risk-color: #475569;
+			--risk-active-border: rgba(100, 116, 139, 0.44);
+			--risk-active-bg: linear-gradient(135deg, rgba(100, 116, 139, 0.18), rgba(71, 85, 105, 0.12));
+			--risk-active-color: #334155;
+			--risk-shadow: rgba(100, 116, 139, 0.1);
+		}
+
 		html[data-theme='light'] .filter-chip-risk:hover,
 		html[data-theme='light'] .filter-chip-risk.is-active {
 			border-color: var(--risk-active-border);
@@ -4427,7 +4449,8 @@ function generateHTML(备案内容) {
 			{ key: 'low', label: '纯净' },
 			{ key: 'elevated', label: '轻微风险' },
 			{ key: 'high', label: '高风险' },
-			{ key: 'critical', label: '极度危险' }
+			{ key: 'critical', label: '极度危险' },
+			{ key: 'unknown', label: '未知' }
 		];
 		const PRIMARY_RESULT_FILTERS = [
 			{ key: 'all', label: '全部' },
@@ -5818,6 +5841,7 @@ function generateHTML(备案内容) {
 		}
 
 		function getRiskFilterSeverity(filterKey) {
+			if (filterKey === 'unknown') return -1;
 			return RISK_RESULT_FILTERS.findIndex(function (filter) {
 				return filter.key === filterKey;
 			});


### PR DESCRIPTION
This pull request adds support for an "unknown" risk level throughout the UI, including styling, filtering, and labeling. The changes ensure that items with an unknown risk status are visually distinct and can be filtered correctly.

**Risk level support:**

* Added a new "unknown" risk level to the `RISK_RESULT_FILTERS` array, including the label "未知" for display purposes.
* Updated the `getRiskFilterSeverity` function to handle the "unknown" risk level by returning a severity of -1 for this case.

**Styling updates:**

* Added CSS variables and styles for `.filter-chip-risk.risk-unknown` and `.meta-chip-risk.risk-unknown` to ensure the "unknown" risk level has a distinct appearance in both default and light themes. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR2884-R2894) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bR3864-R3874)