### PR TITLE
Beta2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sstp://username:password@host:443
 
 ### TURN 支持说明
 
-`turn://` 目标会被当作 TURN over TCP 服务器检测。Worker 会先连接 TURN 服务器，再通过 TURN TCP 中继访问 `api.ipapi.is:443`，最后读取出口 IP 信息。
+`turn://` 目标会被当作 TURN over TCP 服务器检测。Worker 会先连接 TURN 服务器，再通过 TURN TCP 中继访问 `www.iplocate.io:443`，最后读取出口 IP 信息。
 
 当前 TURN 实现有以下边界：
 
@@ -85,7 +85,7 @@ sstp://username:password@host:443
 
 ### SSTP 支持说明
 
-`sstp://` 目标会被当作 SSTP over TLS 服务器检测。Worker 会先建立 SSTP HTTP 隧道，再完成 PPP / IPCP 协商，随后在 PPP 内构造 TCP 连接访问 `api.ipapi.is:443`，最后读取出口 IP 信息。
+`sstp://` 目标会被当作 SSTP over TLS 服务器检测。Worker 会先建立 SSTP HTTP 隧道，再完成 PPP / IPCP 协商，随后在 PPP 内构造 TCP 连接访问 `www.iplocate.io:443`，最后读取出口 IP 信息。
 
 当前 SSTP 实现有以下边界：
 
@@ -99,7 +99,7 @@ sstp://username:password@host:443
 
 ### `GET /check`
 
-检测单个代理是否可用。Worker 会通过代理建立到 `api.ipapi.is` 的连接，并读取该服务返回的出口 IP 信息。
+检测单个代理是否可用。Worker 会通过代理建立到 `www.iplocate.io` 的连接，并读取该服务返回的出口 IP 信息。
 
 请求参数支持以下写法：
 
@@ -245,7 +245,7 @@ https://your-worker.example.workers.dev/socks5://proxy.example.com:1080
 ## 注意事项
 
 - Cloudflare Workers 的 TCP Socket 能力由 `cloudflare:sockets` 提供，请确保部署环境支持 Workers TCP 出站连接。
-- 检测逻辑会把代理作为隧道访问 `api.ipapi.is`，因此结果反映的是该代理访问该目标服务时的可用性和出口信息。
+- 检测逻辑会把代理作为隧道访问 `www.iplocate.io`，因此结果反映的是该代理访问该目标服务时的可用性和出口信息。
 - TURN 检测依赖 TURN 服务器支持 TCP relay / CONNECT；只支持 UDP relay 的 TURN 服务会检测失败。
 - SSTP 检测依赖服务端支持 SSTP over TLS、PPP / IPCP 和 IPv4 分配；仅支持 PAP 认证，不支持 MS-CHAP 等其他 PPP 认证方式。
 - 公开部署时请谨慎使用真实代理账号密码；当前页面和接口没有访问令牌保护。
@@ -263,7 +263,7 @@ https://your-worker.example.workers.dev/socks5://proxy.example.com:1080
 ## 致谢
 - [@Alexandre_Kojeve](https://t.me/Alexandre_Kojeve)
 - [Cloudflare Workers](https://workers.cloudflare.com/)
-- [ipapi.is](https://ipapi.is/)
+- [iplocate.io](https://www.iplocate.io/)
 - [Cloudflare DNS](https://cloudflare-dns.com/)
 - [OpenStreetMap](https://www.openstreetmap.org/)
 - [Leaflet](https://leafletjs.com/)

--- a/_worker.js
+++ b/_worker.js
@@ -337,13 +337,13 @@ async function checkProxy({ type, value }, colo) {
 				} : exit.asn,
 				rir: exit.asn?.rir || null,
 				is_datacenter: exit.privacy?.is_hosting || false,
-			is_crawler: false,
-			is_bogon: exit.privacy?.is_bogon || false,
-			is_proxy: exit.privacy?.is_proxy || false,
-			is_vpn: exit.privacy?.is_vpn || false,
-			is_tor: exit.privacy?.is_tor || false,
-			is_abuser: exit.privacy?.is_abuser || false,
-		};
+				is_crawler: false,
+				is_bogon: exit.privacy?.is_bogon || false,
+				is_proxy: exit.privacy?.is_proxy || false,
+				is_vpn: exit.privacy?.is_vpn || false,
+				is_tor: exit.privacy?.is_tor || false,
+				is_abuser: exit.privacy?.is_abuser || false,
+			};
 		} finally {
 			try { tlsSocket.close(); } catch (e) { }
 		}

--- a/_worker.js
+++ b/_worker.js
@@ -232,7 +232,7 @@ async function checkProxy({ type, value }, colo) {
 	}
 
 	let tunnel = null;
-	const targetHost = 'api.ipapi.is';
+	const targetHost = 'www.iplocate.io';
 	const targetPort = 443;
 
 	try {
@@ -261,7 +261,7 @@ async function checkProxy({ type, value }, colo) {
 		try {
 			await withTimeout(tlsSocket.handshake(), CHECK_TIMEOUT_MS, 'Target TLS handshake timed out');
 			await tlsSocket.write(encoder.encode([
-				'GET / HTTP/1.1',
+				'GET /api/lookup HTTP/1.1',
 				`Host: ${targetHost}`,
 				'User-Agent: Mozilla/5.0 CF-Workers-CheckProxy/2.0',
 				'Accept: application/json',
@@ -296,7 +296,7 @@ async function checkProxy({ type, value }, colo) {
 			const statusMatch = statusLine.match(/HTTP\/\d(?:\.\d)?\s+(\d+)/i);
 			const statusCode = statusMatch ? Number(statusMatch[1]) : NaN;
 			if (!Number.isFinite(statusCode) || statusCode < 200 || statusCode >= 300) {
-				throw new Error(`Target /ip.json request failed: ${statusLine || 'invalid status'}`);
+				throw new Error(`Target /api/lookup request failed: ${statusLine || 'invalid status'}`);
 			}
 
 			let bodyBytes = responseBuffer.slice(headerEndIndex);
@@ -324,8 +324,26 @@ async function checkProxy({ type, value }, colo) {
 			try {
 				exit = JSON.parse(bodyText.trim());
 			} catch (error) {
-				throw new Error('Target /ip.json did not return valid JSON');
+				throw new Error('Target /api/lookup did not return valid JSON');
 			}
+
+			// Transform iplocate.io response to maintain compatibility with existing frontend
+			exit = {
+				...exit,
+				asn: exit.asn ? {
+					...exit.asn,
+					org: exit.asn.name,
+					descr: exit.asn.name,
+				} : exit.asn,
+				rir: exit.asn?.rir || null,
+				is_datacenter: exit.privacy?.is_hosting || false,
+			is_crawler: false,
+			is_bogon: exit.privacy?.is_bogon || false,
+			is_proxy: exit.privacy?.is_proxy || false,
+			is_vpn: exit.privacy?.is_vpn || false,
+			is_tor: exit.privacy?.is_tor || false,
+			is_abuser: exit.privacy?.is_abuser || false,
+		};
 		} finally {
 			try { tlsSocket.close(); } catch (e) { }
 		}
@@ -6685,12 +6703,12 @@ function generateHTML(备案内容) {
 				latitude !== '' && longitude !== '' ? String(latitude) + ',' + String(longitude) : ''
 			);
 			const asn = firstNonEmpty(typeof exit.asn === 'object' ? '' : exit.asn, asnInfo.asn);
-			const asOrganization = firstNonEmpty(exit.asOrganization, exit.org, asnInfo.org, asnInfo.descr, company.name);
+			const asOrganization = firstNonEmpty(exit.asOrganization, exit.org, asnInfo.org, asnInfo.descr, asnInfo.name, company.name);
 			let countryCode = firstNonEmpty(exit.countryCode, exit.country_code, location.country_code, asnInfo.country);
 			if (/^[a-z]{2}$/i.test(String(countryCode || '').trim())) {
 				countryCode = String(countryCode).trim().toUpperCase();
 			}
-			const countryName = firstNonEmpty(exit.countryName, location.country);
+			const countryName = firstNonEmpty(exit.countryName, exit.country, location.country);
 			const ip = firstNonEmpty(exit.ip);
 
 			return Object.assign({}, exit, {
@@ -6705,11 +6723,11 @@ function generateHTML(备案内容) {
 				countryCode: countryCode,
 				country_code: countryCode,
 				countryName: countryName,
-				region: firstNonEmpty(exit.region, exit.regionName, location.state),
+				region: firstNonEmpty(exit.region, exit.regionName, exit.subdivision, location.state),
 				regionCode: firstNonEmpty(exit.regionCode, location.state_code),
 				city: firstNonEmpty(exit.city, location.city),
-				postalCode: firstNonEmpty(exit.postalCode, location.zip),
-				timezone: firstNonEmpty(exit.timezone, location.timezone),
+				postalCode: firstNonEmpty(exit.postalCode, exit.postal_code, location.zip),
+				timezone: firstNonEmpty(exit.timezone, exit.time_zone, location.timezone),
 				loc: loc,
 				latitude: latitude,
 				longitude: longitude
@@ -6825,7 +6843,7 @@ function generateHTML(备案内容) {
 					itemObj.info.innerHTML =
 						'<span class="result-label">候选目标</span>' +
 						buildCopyableTarget(target) +
-						'<span class="result-detail">无法通过该代理访问 api.ipapi.is，请更换目标后重试。</span>';
+						'<span class="result-detail">无法通过该代理访问 www.iplocate.io，请更换目标后重试。</span>';
 					itemObj.meta.innerHTML =
 						buildMetaChip('检测未通过', 'error', 'meta-chip-danger') +
 						buildMetaChip(data.error || data.message || '远端返回失败结果', 'info');


### PR DESCRIPTION
This pull request updates the proxy checking logic to use `www.iplocate.io` instead of `api.ipapi.is` as the target service for determining exit IP information. It also adapts the code and documentation to match the new service's API and response format, ensuring compatibility with the existing frontend display.

**Migration to new IP information service:**

* Replaced all references to `api.ipapi.is` with `www.iplocate.io` in the proxy check logic, including the target host, HTTP path (`/api/lookup`), and error messages in `_worker.js`. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL235-R235) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL264-R264) [[3]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL299-R299) [[4]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL327-R346)
* Transformed the response from `iplocate.io` to maintain compatibility with the existing frontend, including mapping ASN and privacy fields to the expected format.

**Frontend and display compatibility:**

* Updated the frontend data mapping logic in `generateHTML` to handle new or renamed fields from `iplocate.io`, ensuring region, postal code, timezone, and organization information are displayed correctly. [[1]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL6688-R6711) [[2]](diffhunk://#diff-bbf67d84ac96e31a931538e71febf55f6631e9d846c8ab52097ba3a5f303197bL6708-R6730)

**Documentation updates:**

* Updated all relevant sections in `README.md` to reference `www.iplocate.io` instead of `api.ipapi.is`, including usage explanations for TURN/SSTP, the `/check` endpoint, notes, and acknowledgements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R77) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R102) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L248-R248) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L266-R266)
* Updated error messages in the UI to reference `www.iplocate.io` for clarity.