### PR TITLE
修复 https 代理被域名转 IP 解析导致丢失 SNI 的问题

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1680,7 +1680,8 @@ function isIPv4(value) {
 async function handleResolve(input) {
 	let text = String(input || '').trim().split('#')[0].trim();
 	const proxy = splitProxyScheme(text);
-	if (proxy?.type === 'sstp') {
+	// sstp/https 依赖域名建立 TLS（SNI），须保留原始 host，不做 DNS 展平
+	if (proxy?.type === 'sstp' || proxy?.type === 'https') {
 		const parsed = parseProxyAddress(text, proxy.type, DEFAULT_PORTS[proxy.type]);
 		return [`${parsed.hostname}:${parsed.port}`];
 	}
@@ -5297,7 +5298,7 @@ function generateHTML(备案内容) {
 
 		function getDirectProxyTarget(input) {
 			const parsed = parseProxyUrl(input);
-			if (parsed.scheme === 'sstp') return parsed.normalized;
+			if (parsed.scheme === 'sstp' || parsed.scheme === 'https') return parsed.normalized;
 			return isClientIpAddress(parsed.hostPlain) ? parsed.normalized : '';
 		}
 
@@ -5315,7 +5316,7 @@ function generateHTML(备案内容) {
 
 		function replaceProxyHost(proxyUrl, resolvedTarget) {
 			const parsed = parseProxyUrl(proxyUrl);
-			if (parsed.scheme === 'sstp') return parsed.normalized;
+			if (parsed.scheme === 'sstp' || parsed.scheme === 'https') return parsed.normalized;
 			const target = parseResolvedTarget(resolvedTarget);
 			return normalizeParsedProxyParts(parsed.scheme, parsed.auth, target.host, target.port || parsed.port).normalized;
 		}


### PR DESCRIPTION
网页端提交 https 代理（如 https://user:pass@cdn域名:1443）时，解析链路会把 代理域名 DNS 展平为 IP 列表再逐个检测，https 代理以 IP 发起 TLS、丢失域名
SNI，导致握手失败。

将 https 与 sstp（同为 TLS 型）的保域名语义对齐：
- handleResolve：https 域名直接返回 hostname:port，不做 DoH 展平
- getDirectProxyTarget：https 域名直接作为检测目标，跳过 /resolve
- replaceProxyHost：https 一律禁止用解析出的 IP 替换 host

socks5/http/turn 的域名解析行为保持不变；demo/ 目录不同步。